### PR TITLE
[FEATURE] 제품 등록 어드민 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,11 +27,13 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testRuntimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/or/ecogad/ecogad/api/product/AdminProductController.java
+++ b/src/main/java/or/ecogad/ecogad/api/product/AdminProductController.java
@@ -1,0 +1,46 @@
+package or.ecogad.ecogad.api.product;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import or.ecogad.ecogad.api.product.dto.AdminProductCreateRequest;
+import or.ecogad.ecogad.api.product.dto.AdminProductCreateResponse;
+import or.ecogad.ecogad.core.api.ApiResponse;
+import or.ecogad.ecogad.domain.product.entity.Product;
+import or.ecogad.ecogad.domain.product.entity.ProductCategory;
+import or.ecogad.ecogad.domain.product.service.AdminProductService;
+import or.ecogad.ecogad.domain.product.service.command.ProductCreateCommand;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/products")
+public class AdminProductController {
+
+    private final AdminProductService adminProductService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<AdminProductCreateResponse>> createProduct(
+            @Valid @RequestBody AdminProductCreateRequest request
+    ) {
+        ProductCreateCommand command = new ProductCreateCommand(
+                ProductCategory.from(request.category()),
+                request.name(),
+                request.summary(),
+                request.description(),
+                request.thumbnailUrl(),
+                request.published()
+        );
+
+        Product created = adminProductService.createProduct(command);
+        AdminProductCreateResponse response = AdminProductCreateResponse.from(created);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/or/ecogad/ecogad/api/product/dto/AdminProductCreateRequest.java
+++ b/src/main/java/or/ecogad/ecogad/api/product/dto/AdminProductCreateRequest.java
@@ -1,0 +1,24 @@
+package or.ecogad.ecogad.api.product.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AdminProductCreateRequest(
+        @NotBlank(message = "카테고리는 필수입니다.")
+        String category,
+
+        @NotBlank(message = "제품명은 필수입니다.")
+        @Size(max = 150, message = "제품명은 150자 이하여야 합니다.")
+        String name,
+
+        @Size(max = 255, message = "요약은 255자 이하여야 합니다.")
+        String summary,
+
+        String description,
+
+        @Size(max = 500, message = "썸네일 URL은 500자 이하여야 합니다.")
+        String thumbnailUrl,
+
+        boolean published
+) {
+}

--- a/src/main/java/or/ecogad/ecogad/api/product/dto/AdminProductCreateResponse.java
+++ b/src/main/java/or/ecogad/ecogad/api/product/dto/AdminProductCreateResponse.java
@@ -1,0 +1,29 @@
+package or.ecogad.ecogad.api.product.dto;
+
+import or.ecogad.ecogad.domain.product.entity.Product;
+
+import java.time.LocalDateTime;
+
+public record AdminProductCreateResponse(
+        Long id,
+        String category,
+        String name,
+        String summary,
+        String description,
+        String thumbnailUrl,
+        boolean published,
+        LocalDateTime createdAt
+) {
+    public static AdminProductCreateResponse from(Product product) {
+        return new AdminProductCreateResponse(
+                product.getId(),
+                product.getCategory().name(),
+                product.getName(),
+                product.getSummary(),
+                product.getDescription(),
+                product.getThumbnailUrl(),
+                product.isPublished(),
+                product.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/or/ecogad/ecogad/core/api/ApiError.java
+++ b/src/main/java/or/ecogad/ecogad/core/api/ApiError.java
@@ -1,0 +1,4 @@
+package or.ecogad.ecogad.core.api;
+
+public record ApiError(String code, String message) {
+}

--- a/src/main/java/or/ecogad/ecogad/core/api/ApiResponse.java
+++ b/src/main/java/or/ecogad/ecogad/core/api/ApiResponse.java
@@ -1,0 +1,12 @@
+package or.ecogad.ecogad.core.api;
+
+public record ApiResponse<T>(boolean success, T data, ApiError error) {
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, data, null);
+    }
+
+    public static <T> ApiResponse<T> failure(String code, String message) {
+        return new ApiResponse<>(false, null, new ApiError(code, message));
+    }
+}

--- a/src/main/java/or/ecogad/ecogad/core/config/JpaAuditingConfig.java
+++ b/src/main/java/or/ecogad/ecogad/core/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package or.ecogad.ecogad.core.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/or/ecogad/ecogad/core/exception/CustomException.java
+++ b/src/main/java/or/ecogad/ecogad/core/exception/CustomException.java
@@ -1,0 +1,20 @@
+package or.ecogad.ecogad.core.exception;
+
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.message());
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/or/ecogad/ecogad/core/exception/ErrorCode.java
+++ b/src/main/java/or/ecogad/ecogad/core/exception/ErrorCode.java
@@ -1,0 +1,32 @@
+package or.ecogad.ecogad.core.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C400", "요청 값이 올바르지 않습니다."),
+    INVALID_PRODUCT_CATEGORY(HttpStatus.BAD_REQUEST, "P400", "유효하지 않은 제품 카테고리입니다."),
+    DUPLICATE_PRODUCT(HttpStatus.CONFLICT, "P409", "동일 카테고리에 같은 이름의 제품이 이미 존재합니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C500", "서버 내부 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    public HttpStatus status() {
+        return status;
+    }
+
+    public String code() {
+        return code;
+    }
+
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/or/ecogad/ecogad/core/exception/GlobalExceptionHandler.java
+++ b/src/main/java/or/ecogad/ecogad/core/exception/GlobalExceptionHandler.java
@@ -1,0 +1,37 @@
+package or.ecogad.ecogad.core.exception;
+
+import or.ecogad.ecogad.core.api.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException exception) {
+        ErrorCode errorCode = exception.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.status())
+                .body(ApiResponse.failure(errorCode.code(), exception.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValid(MethodArgumentNotValidException exception) {
+        FieldError fieldError = exception.getBindingResult().getFieldError();
+        String message = fieldError == null ? ErrorCode.INVALID_INPUT_VALUE.message() : fieldError.getDefaultMessage();
+
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT_VALUE.status())
+                .body(ApiResponse.failure(ErrorCode.INVALID_INPUT_VALUE.code(), message));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception exception) {
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.status())
+                .body(ApiResponse.failure(ErrorCode.INTERNAL_SERVER_ERROR.code(), ErrorCode.INTERNAL_SERVER_ERROR.message()));
+    }
+}

--- a/src/main/java/or/ecogad/ecogad/domain/common/BaseEntity.java
+++ b/src/main/java/or/ecogad/ecogad/domain/common/BaseEntity.java
@@ -1,0 +1,25 @@
+package or.ecogad.ecogad.domain.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/or/ecogad/ecogad/domain/product/entity/Product.java
+++ b/src/main/java/or/ecogad/ecogad/domain/product/entity/Product.java
@@ -1,0 +1,72 @@
+package or.ecogad.ecogad.domain.product.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import or.ecogad.ecogad.domain.common.BaseEntity;
+
+@Getter
+@Entity
+@Table(name = "products")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 40)
+    private ProductCategory category;
+
+    @Column(nullable = false, length = 150)
+    private String name;
+
+    @Column(length = 255)
+    private String summary;
+
+    @Lob
+    private String description;
+
+    @Column(length = 500)
+    private String thumbnailUrl;
+
+    @Column(nullable = false)
+    private boolean published;
+
+    private Product(
+            ProductCategory category,
+            String name,
+            String summary,
+            String description,
+            String thumbnailUrl,
+            boolean published
+    ) {
+        this.category = category;
+        this.name = name;
+        this.summary = summary;
+        this.description = description;
+        this.thumbnailUrl = thumbnailUrl;
+        this.published = published;
+    }
+
+    public static Product create(
+            ProductCategory category,
+            String name,
+            String summary,
+            String description,
+            String thumbnailUrl,
+            boolean published
+    ) {
+        return new Product(category, name, summary, description, thumbnailUrl, published);
+    }
+}

--- a/src/main/java/or/ecogad/ecogad/domain/product/entity/ProductCategory.java
+++ b/src/main/java/or/ecogad/ecogad/domain/product/entity/ProductCategory.java
@@ -1,0 +1,23 @@
+package or.ecogad.ecogad.domain.product.entity;
+
+import or.ecogad.ecogad.core.exception.CustomException;
+import or.ecogad.ecogad.core.exception.ErrorCode;
+
+public enum ProductCategory {
+    ULPA,
+    HEPA,
+    MEDIUM,
+    PRE,
+    CHEMICAL,
+    CLEAN_EQUIPMENT,
+    CLEANROOM_MAINTENANCE,
+    ETC;
+
+    public static ProductCategory from(String value) {
+        try {
+            return ProductCategory.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException | NullPointerException exception) {
+            throw new CustomException(ErrorCode.INVALID_PRODUCT_CATEGORY);
+        }
+    }
+}

--- a/src/main/java/or/ecogad/ecogad/domain/product/repository/ProductRepository.java
+++ b/src/main/java/or/ecogad/ecogad/domain/product/repository/ProductRepository.java
@@ -1,0 +1,10 @@
+package or.ecogad.ecogad.domain.product.repository;
+
+import or.ecogad.ecogad.domain.product.entity.Product;
+import or.ecogad.ecogad.domain.product.entity.ProductCategory;
+
+public interface ProductRepository {
+    Product save(Product product);
+
+    boolean existsByCategoryAndName(ProductCategory category, String name);
+}

--- a/src/main/java/or/ecogad/ecogad/domain/product/service/AdminProductService.java
+++ b/src/main/java/or/ecogad/ecogad/domain/product/service/AdminProductService.java
@@ -1,0 +1,36 @@
+package or.ecogad.ecogad.domain.product.service;
+
+import lombok.RequiredArgsConstructor;
+import or.ecogad.ecogad.core.exception.CustomException;
+import or.ecogad.ecogad.core.exception.ErrorCode;
+import or.ecogad.ecogad.domain.product.entity.Product;
+import or.ecogad.ecogad.domain.product.repository.ProductRepository;
+import or.ecogad.ecogad.domain.product.service.command.ProductCreateCommand;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminProductService {
+
+    private final ProductRepository productRepository;
+
+    @Transactional
+    public Product createProduct(ProductCreateCommand command) {
+        boolean isDuplicate = productRepository.existsByCategoryAndName(command.category(), command.name());
+        if (isDuplicate) {
+            throw new CustomException(ErrorCode.DUPLICATE_PRODUCT);
+        }
+
+        Product product = Product.create(
+                command.category(),
+                command.name(),
+                command.summary(),
+                command.description(),
+                command.thumbnailUrl(),
+                command.published()
+        );
+
+        return productRepository.save(product);
+    }
+}

--- a/src/main/java/or/ecogad/ecogad/domain/product/service/command/ProductCreateCommand.java
+++ b/src/main/java/or/ecogad/ecogad/domain/product/service/command/ProductCreateCommand.java
@@ -1,0 +1,13 @@
+package or.ecogad.ecogad.domain.product.service.command;
+
+import or.ecogad.ecogad.domain.product.entity.ProductCategory;
+
+public record ProductCreateCommand(
+        ProductCategory category,
+        String name,
+        String summary,
+        String description,
+        String thumbnailUrl,
+        boolean published
+) {
+}

--- a/src/main/java/or/ecogad/ecogad/infra/product/jpa/ProductJpaRepository.java
+++ b/src/main/java/or/ecogad/ecogad/infra/product/jpa/ProductJpaRepository.java
@@ -1,0 +1,9 @@
+package or.ecogad.ecogad.infra.product.jpa;
+
+import or.ecogad.ecogad.domain.product.entity.Product;
+import or.ecogad.ecogad.domain.product.entity.ProductCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductJpaRepository extends JpaRepository<Product, Long> {
+    boolean existsByCategoryAndName(ProductCategory category, String name);
+}

--- a/src/main/java/or/ecogad/ecogad/infra/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/or/ecogad/ecogad/infra/product/repository/ProductRepositoryImpl.java
@@ -1,0 +1,25 @@
+package or.ecogad.ecogad.infra.product.repository;
+
+import lombok.RequiredArgsConstructor;
+import or.ecogad.ecogad.domain.product.entity.Product;
+import or.ecogad.ecogad.domain.product.entity.ProductCategory;
+import or.ecogad.ecogad.domain.product.repository.ProductRepository;
+import or.ecogad.ecogad.infra.product.jpa.ProductJpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductRepositoryImpl implements ProductRepository {
+
+    private final ProductJpaRepository productJpaRepository;
+
+    @Override
+    public Product save(Product product) {
+        return productJpaRepository.save(product);
+    }
+
+    @Override
+    public boolean existsByCategoryAndName(ProductCategory category, String name) {
+        return productJpaRepository.existsByCategoryAndName(category, name);
+    }
+}

--- a/src/test/java/or/ecogad/ecogad/domain/product/service/AdminProductServiceTest.java
+++ b/src/test/java/or/ecogad/ecogad/domain/product/service/AdminProductServiceTest.java
@@ -1,0 +1,68 @@
+package or.ecogad.ecogad.domain.product.service;
+
+import or.ecogad.ecogad.core.exception.CustomException;
+import or.ecogad.ecogad.domain.product.entity.Product;
+import or.ecogad.ecogad.domain.product.entity.ProductCategory;
+import or.ecogad.ecogad.domain.product.repository.ProductRepository;
+import or.ecogad.ecogad.domain.product.service.command.ProductCreateCommand;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminProductServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private AdminProductService adminProductService;
+
+    @Test
+    @DisplayName("createProduct()는 제품을 성공적으로 등록한다")
+    void createProduct_success() {
+        ProductCreateCommand command = new ProductCreateCommand(
+                ProductCategory.ULPA,
+                "초정밀 ULPA 필터",
+                "테스트 요약",
+                "테스트 설명",
+                "https://example.com/filter.jpg",
+                true
+        );
+
+        when(productRepository.existsByCategoryAndName(ProductCategory.ULPA, "초정밀 ULPA 필터")).thenReturn(false);
+        when(productRepository.save(any(Product.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        adminProductService.createProduct(command);
+
+        verify(productRepository, times(1)).save(any(Product.class));
+    }
+
+    @Test
+    @DisplayName("createProduct()는 중복 제품일 때 예외를 발생시킨다")
+    void createProduct_duplicate_throwsException() {
+        ProductCreateCommand command = new ProductCreateCommand(
+                ProductCategory.ULPA,
+                "초정밀 ULPA 필터",
+                "테스트 요약",
+                "테스트 설명",
+                null,
+                false
+        );
+
+        when(productRepository.existsByCategoryAndName(ProductCategory.ULPA, "초정밀 ULPA 필터")).thenReturn(true);
+
+        assertThrows(CustomException.class, () -> adminProductService.createProduct(command));
+        verify(productRepository, never()).save(any(Product.class));
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- close #1


<br><br>

## 📝 Summary

- 제품 등록 어드민 API 추가 (`POST /api/v1/admin/products`)
- 공통 응답/예외 규약 추가 (`ApiResponse`, `ErrorCode`, `CustomException`, `GlobalExceptionHandler`)
- 제품 도메인/인프라 계층 분리 구현 (`domain repository interface` + `infra implementation`)
- 제품 등록 서비스 단위 테스트 추가


<br><br>

## 🙏 Details

- 패키지 구조를 `api/core/domain/infra`로 분리해 컨벤션에 맞춤
- `ProductCategory.from()`으로 카테고리 파싱 및 유효성 검증
- 중복 제품 등록 방지 로직 추가 (`existsByCategoryAndName`)
- JPA Auditing과 `BaseEntity(createdAt, updatedAt)` 공통화
- 검증/실행 확인: `./gradlew test` 성공
