### PR TITLE
[FEATURE] 견적 문의 이메일 알림 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/or/ecogad/ecogad/api/inquiry/InquiryController.java
+++ b/src/main/java/or/ecogad/ecogad/api/inquiry/InquiryController.java
@@ -1,0 +1,45 @@
+package or.ecogad.ecogad.api.inquiry;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import or.ecogad.ecogad.api.inquiry.dto.InquiryCreateRequest;
+import or.ecogad.ecogad.api.inquiry.dto.InquiryCreateResponse;
+import or.ecogad.ecogad.core.api.ApiResponse;
+import or.ecogad.ecogad.domain.inquiry.entity.QuoteInquiry;
+import or.ecogad.ecogad.domain.inquiry.service.InquiryService;
+import or.ecogad.ecogad.domain.inquiry.service.command.InquiryCreateCommand;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/inquiries")
+public class InquiryController {
+
+    private final InquiryService inquiryService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<InquiryCreateResponse>> createInquiry(
+            @Valid @RequestBody InquiryCreateRequest request
+    ) {
+        InquiryCreateCommand command = new InquiryCreateCommand(
+                request.name(),
+                request.companyName(),
+                request.phone(),
+                request.email(),
+                request.message(),
+                request.privacyAgreed()
+        );
+
+        QuoteInquiry created = inquiryService.createInquiry(command);
+        InquiryCreateResponse response = InquiryCreateResponse.from(created);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/or/ecogad/ecogad/api/inquiry/dto/InquiryCreateRequest.java
+++ b/src/main/java/or/ecogad/ecogad/api/inquiry/dto/InquiryCreateRequest.java
@@ -1,0 +1,32 @@
+package or.ecogad.ecogad.api.inquiry.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record InquiryCreateRequest(
+        @NotBlank(message = "이름은 필수입니다.")
+        @Size(max = 80, message = "이름은 80자 이하여야 합니다.")
+        String name,
+
+        @NotBlank(message = "회사명은 필수입니다.")
+        @Size(max = 120, message = "회사명은 120자 이하여야 합니다.")
+        String companyName,
+
+        @NotBlank(message = "연락처는 필수입니다.")
+        @Size(max = 30, message = "연락처는 30자 이하여야 합니다.")
+        String phone,
+
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @Size(max = 120, message = "이메일은 120자 이하여야 합니다.")
+        String email,
+
+        @NotBlank(message = "문의내용은 필수입니다.")
+        String message,
+
+        @AssertTrue(message = "개인정보 동의가 필요합니다.")
+        boolean privacyAgreed
+) {
+}

--- a/src/main/java/or/ecogad/ecogad/api/inquiry/dto/InquiryCreateResponse.java
+++ b/src/main/java/or/ecogad/ecogad/api/inquiry/dto/InquiryCreateResponse.java
@@ -1,0 +1,19 @@
+package or.ecogad.ecogad.api.inquiry.dto;
+
+import or.ecogad.ecogad.domain.inquiry.entity.QuoteInquiry;
+
+import java.time.LocalDateTime;
+
+public record InquiryCreateResponse(
+        Long id,
+        String status,
+        LocalDateTime createdAt
+) {
+    public static InquiryCreateResponse from(QuoteInquiry inquiry) {
+        return new InquiryCreateResponse(
+                inquiry.getId(),
+                inquiry.getStatus().name(),
+                inquiry.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/or/ecogad/ecogad/core/exception/ErrorCode.java
+++ b/src/main/java/or/ecogad/ecogad/core/exception/ErrorCode.java
@@ -6,6 +6,7 @@ public enum ErrorCode {
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C400", "요청 값이 올바르지 않습니다."),
     INVALID_PRODUCT_CATEGORY(HttpStatus.BAD_REQUEST, "P400", "유효하지 않은 제품 카테고리입니다."),
     DUPLICATE_PRODUCT(HttpStatus.CONFLICT, "P409", "동일 카테고리에 같은 이름의 제품이 이미 존재합니다."),
+    INQUIRY_NOTIFICATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "I500", "견적 문의 알림 메일 전송에 실패했습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C500", "서버 내부 오류가 발생했습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/or/ecogad/ecogad/domain/inquiry/entity/InquiryStatus.java
+++ b/src/main/java/or/ecogad/ecogad/domain/inquiry/entity/InquiryStatus.java
@@ -1,0 +1,7 @@
+package or.ecogad.ecogad.domain.inquiry.entity;
+
+public enum InquiryStatus {
+    RECEIVED,
+    IN_PROGRESS,
+    DONE
+}

--- a/src/main/java/or/ecogad/ecogad/domain/inquiry/entity/QuoteInquiry.java
+++ b/src/main/java/or/ecogad/ecogad/domain/inquiry/entity/QuoteInquiry.java
@@ -1,0 +1,77 @@
+package or.ecogad.ecogad.domain.inquiry.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import or.ecogad.ecogad.domain.common.BaseEntity;
+
+@Getter
+@Entity
+@Table(name = "quote_inquiries")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuoteInquiry extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 80)
+    private String name;
+
+    @Column(nullable = false, length = 120)
+    private String companyName;
+
+    @Column(nullable = false, length = 30)
+    private String phone;
+
+    @Column(nullable = false, length = 120)
+    private String email;
+
+    @Lob
+    @Column(nullable = false)
+    private String message;
+
+    @Column(nullable = false)
+    private boolean privacyAgreed;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private InquiryStatus status;
+
+    private QuoteInquiry(
+            String name,
+            String companyName,
+            String phone,
+            String email,
+            String message,
+            boolean privacyAgreed
+    ) {
+        this.name = name;
+        this.companyName = companyName;
+        this.phone = phone;
+        this.email = email;
+        this.message = message;
+        this.privacyAgreed = privacyAgreed;
+        this.status = InquiryStatus.RECEIVED;
+    }
+
+    public static QuoteInquiry create(
+            String name,
+            String companyName,
+            String phone,
+            String email,
+            String message,
+            boolean privacyAgreed
+    ) {
+        return new QuoteInquiry(name, companyName, phone, email, message, privacyAgreed);
+    }
+}

--- a/src/main/java/or/ecogad/ecogad/domain/inquiry/port/InquiryNotificationSender.java
+++ b/src/main/java/or/ecogad/ecogad/domain/inquiry/port/InquiryNotificationSender.java
@@ -1,0 +1,7 @@
+package or.ecogad.ecogad.domain.inquiry.port;
+
+import or.ecogad.ecogad.domain.inquiry.entity.QuoteInquiry;
+
+public interface InquiryNotificationSender {
+    void send(QuoteInquiry inquiry);
+}

--- a/src/main/java/or/ecogad/ecogad/domain/inquiry/repository/QuoteInquiryRepository.java
+++ b/src/main/java/or/ecogad/ecogad/domain/inquiry/repository/QuoteInquiryRepository.java
@@ -1,0 +1,7 @@
+package or.ecogad.ecogad.domain.inquiry.repository;
+
+import or.ecogad.ecogad.domain.inquiry.entity.QuoteInquiry;
+
+public interface QuoteInquiryRepository {
+    QuoteInquiry save(QuoteInquiry quoteInquiry);
+}

--- a/src/main/java/or/ecogad/ecogad/domain/inquiry/service/InquiryService.java
+++ b/src/main/java/or/ecogad/ecogad/domain/inquiry/service/InquiryService.java
@@ -1,0 +1,41 @@
+package or.ecogad.ecogad.domain.inquiry.service;
+
+import lombok.RequiredArgsConstructor;
+import or.ecogad.ecogad.core.exception.CustomException;
+import or.ecogad.ecogad.core.exception.ErrorCode;
+import or.ecogad.ecogad.domain.inquiry.entity.QuoteInquiry;
+import or.ecogad.ecogad.domain.inquiry.port.InquiryNotificationSender;
+import or.ecogad.ecogad.domain.inquiry.repository.QuoteInquiryRepository;
+import or.ecogad.ecogad.domain.inquiry.service.command.InquiryCreateCommand;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class InquiryService {
+
+    private final QuoteInquiryRepository quoteInquiryRepository;
+    private final InquiryNotificationSender inquiryNotificationSender;
+
+    @Transactional
+    public QuoteInquiry createInquiry(InquiryCreateCommand command) {
+        QuoteInquiry inquiry = QuoteInquiry.create(
+                command.name(),
+                command.companyName(),
+                command.phone(),
+                command.email(),
+                command.message(),
+                command.privacyAgreed()
+        );
+
+        QuoteInquiry saved = quoteInquiryRepository.save(inquiry);
+
+        try {
+            inquiryNotificationSender.send(saved);
+        } catch (RuntimeException exception) {
+            throw new CustomException(ErrorCode.INQUIRY_NOTIFICATION_FAILED);
+        }
+
+        return saved;
+    }
+}

--- a/src/main/java/or/ecogad/ecogad/domain/inquiry/service/command/InquiryCreateCommand.java
+++ b/src/main/java/or/ecogad/ecogad/domain/inquiry/service/command/InquiryCreateCommand.java
@@ -1,0 +1,11 @@
+package or.ecogad.ecogad.domain.inquiry.service.command;
+
+public record InquiryCreateCommand(
+        String name,
+        String companyName,
+        String phone,
+        String email,
+        String message,
+        boolean privacyAgreed
+) {
+}

--- a/src/main/java/or/ecogad/ecogad/infra/inquiry/jpa/QuoteInquiryJpaRepository.java
+++ b/src/main/java/or/ecogad/ecogad/infra/inquiry/jpa/QuoteInquiryJpaRepository.java
@@ -1,0 +1,7 @@
+package or.ecogad.ecogad.infra.inquiry.jpa;
+
+import or.ecogad.ecogad.domain.inquiry.entity.QuoteInquiry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuoteInquiryJpaRepository extends JpaRepository<QuoteInquiry, Long> {
+}

--- a/src/main/java/or/ecogad/ecogad/infra/inquiry/notification/InquiryEmailNotificationSender.java
+++ b/src/main/java/or/ecogad/ecogad/infra/inquiry/notification/InquiryEmailNotificationSender.java
@@ -1,0 +1,41 @@
+package or.ecogad.ecogad.infra.inquiry.notification;
+
+import lombok.RequiredArgsConstructor;
+import or.ecogad.ecogad.domain.inquiry.entity.QuoteInquiry;
+import or.ecogad.ecogad.domain.inquiry.port.InquiryNotificationSender;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class InquiryEmailNotificationSender implements InquiryNotificationSender {
+
+    private final JavaMailSender javaMailSender;
+
+    @Value("${app.mail.inquiry-to}")
+    private String inquiryTo;
+
+    @Value("${app.mail.from:no-reply@ecogad.com}")
+    private String from;
+
+    @Override
+    public void send(QuoteInquiry inquiry) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(inquiryTo);
+        message.setFrom(from);
+        message.setSubject("[ecogad] 신규 견적 문의 접수");
+        message.setText(buildBody(inquiry));
+
+        javaMailSender.send(message);
+    }
+
+    private String buildBody(QuoteInquiry inquiry) {
+        return "이름: " + inquiry.getName() + "\n"
+                + "회사명: " + inquiry.getCompanyName() + "\n"
+                + "연락처: " + inquiry.getPhone() + "\n"
+                + "이메일: " + inquiry.getEmail() + "\n"
+                + "문의내용: " + inquiry.getMessage();
+    }
+}

--- a/src/main/java/or/ecogad/ecogad/infra/inquiry/repository/QuoteInquiryRepositoryImpl.java
+++ b/src/main/java/or/ecogad/ecogad/infra/inquiry/repository/QuoteInquiryRepositoryImpl.java
@@ -1,0 +1,19 @@
+package or.ecogad.ecogad.infra.inquiry.repository;
+
+import lombok.RequiredArgsConstructor;
+import or.ecogad.ecogad.domain.inquiry.entity.QuoteInquiry;
+import or.ecogad.ecogad.domain.inquiry.repository.QuoteInquiryRepository;
+import or.ecogad.ecogad.infra.inquiry.jpa.QuoteInquiryJpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class QuoteInquiryRepositoryImpl implements QuoteInquiryRepository {
+
+    private final QuoteInquiryJpaRepository quoteInquiryJpaRepository;
+
+    @Override
+    public QuoteInquiry save(QuoteInquiry quoteInquiry) {
+        return quoteInquiryJpaRepository.save(quoteInquiry);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,19 @@
 spring.application.name=ecogad
+
+# Database
+spring.datasource.url=${DB_URL:jdbc:h2:mem:ecogad;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
+spring.datasource.username=${DB_USERNAME:sa}
+spring.datasource.password=${DB_PASSWORD:}
+spring.jpa.hibernate.ddl-auto=${JPA_DDL_AUTO:update}
+spring.jpa.open-in-view=false
+
+# Mail
+spring.mail.host=${MAIL_HOST:localhost}
+spring.mail.port=${MAIL_PORT:1025}
+spring.mail.username=${MAIL_USERNAME:}
+spring.mail.password=${MAIL_PASSWORD:}
+spring.mail.properties.mail.smtp.auth=${MAIL_SMTP_AUTH:false}
+spring.mail.properties.mail.smtp.starttls.enable=${MAIL_SMTP_STARTTLS:false}
+
+app.mail.from=${MAIL_FROM:no-reply@ecogad.com}
+app.mail.inquiry-to=${INQUIRY_ALERT_TO:admin@ecogad.com}

--- a/src/test/java/or/ecogad/ecogad/domain/inquiry/service/InquiryServiceTest.java
+++ b/src/test/java/or/ecogad/ecogad/domain/inquiry/service/InquiryServiceTest.java
@@ -1,0 +1,71 @@
+package or.ecogad.ecogad.domain.inquiry.service;
+
+import or.ecogad.ecogad.core.exception.CustomException;
+import or.ecogad.ecogad.domain.inquiry.entity.QuoteInquiry;
+import or.ecogad.ecogad.domain.inquiry.port.InquiryNotificationSender;
+import or.ecogad.ecogad.domain.inquiry.repository.QuoteInquiryRepository;
+import or.ecogad.ecogad.domain.inquiry.service.command.InquiryCreateCommand;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InquiryServiceTest {
+
+    @Mock
+    private QuoteInquiryRepository quoteInquiryRepository;
+
+    @Mock
+    private InquiryNotificationSender inquiryNotificationSender;
+
+    @InjectMocks
+    private InquiryService inquiryService;
+
+    @Test
+    @DisplayName("createInquiry()는 문의를 저장하고 이메일 알림을 전송한다")
+    void createInquiry_success() {
+        InquiryCreateCommand command = new InquiryCreateCommand(
+                "홍길동",
+                "에코가드",
+                "010-1234-5678",
+                "test@ecogad.com",
+                "견적 문의드립니다.",
+                true
+        );
+
+        when(quoteInquiryRepository.save(any(QuoteInquiry.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        inquiryService.createInquiry(command);
+
+        verify(quoteInquiryRepository, times(1)).save(any(QuoteInquiry.class));
+        verify(inquiryNotificationSender, times(1)).send(any(QuoteInquiry.class));
+    }
+
+    @Test
+    @DisplayName("createInquiry()는 이메일 전송 실패 시 예외를 발생시킨다")
+    void createInquiry_mailFailed_throwsException() {
+        InquiryCreateCommand command = new InquiryCreateCommand(
+                "홍길동",
+                "에코가드",
+                "010-1234-5678",
+                "test@ecogad.com",
+                "견적 문의드립니다.",
+                true
+        );
+
+        when(quoteInquiryRepository.save(any(QuoteInquiry.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        doThrow(new RuntimeException("mail error")).when(inquiryNotificationSender).send(any(QuoteInquiry.class));
+
+        assertThrows(CustomException.class, () -> inquiryService.createInquiry(command));
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- close #2


<br><br>

## 📝 Summary

- 견적 문의 API 추가 (`POST /api/v1/inquiries`)
- 견적 문의 저장 도메인/인프라 계층 구현
- 문의 접수 시 이메일 알림 전송 어댑터 구현
- 문의 서비스 단위 테스트 추가


<br><br>

## 🙏 Details

- `QuoteInquiry` 엔티티와 `InquiryStatus` 상태값 추가
- 도메인 서비스(`InquiryService`)에서 저장 후 메일 전송 처리
- 메일 전송 실패 시 `INQUIRY_NOTIFICATION_FAILED` 예외 반환
- 메일/DB 설정을 환경변수 기반으로 `application.properties`에 추가
- 검증/실행 확인: `./gradlew test` 성공
