### PR TITLE
[FEATURE] 공지사항 작성 어드민 API 구현

### DIFF
--- a/src/main/java/or/ecogad/ecogad/api/notice/AdminNoticeController.java
+++ b/src/main/java/or/ecogad/ecogad/api/notice/AdminNoticeController.java
@@ -1,0 +1,42 @@
+package or.ecogad.ecogad.api.notice;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import or.ecogad.ecogad.api.notice.dto.AdminNoticeCreateRequest;
+import or.ecogad.ecogad.api.notice.dto.AdminNoticeCreateResponse;
+import or.ecogad.ecogad.core.api.ApiResponse;
+import or.ecogad.ecogad.domain.notice.entity.Notice;
+import or.ecogad.ecogad.domain.notice.service.AdminNoticeService;
+import or.ecogad.ecogad.domain.notice.service.command.NoticeCreateCommand;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/notices")
+public class AdminNoticeController {
+
+    private final AdminNoticeService adminNoticeService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<AdminNoticeCreateResponse>> createNotice(
+            @Valid @RequestBody AdminNoticeCreateRequest request
+    ) {
+        NoticeCreateCommand command = new NoticeCreateCommand(
+                request.title(),
+                request.content(),
+                request.published()
+        );
+
+        Notice created = adminNoticeService.createNotice(command);
+        AdminNoticeCreateResponse response = AdminNoticeCreateResponse.from(created);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/or/ecogad/ecogad/api/notice/dto/AdminNoticeCreateRequest.java
+++ b/src/main/java/or/ecogad/ecogad/api/notice/dto/AdminNoticeCreateRequest.java
@@ -1,0 +1,16 @@
+package or.ecogad.ecogad.api.notice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AdminNoticeCreateRequest(
+        @NotBlank(message = "공지 제목은 필수입니다.")
+        @Size(max = 200, message = "공지 제목은 200자 이하여야 합니다.")
+        String title,
+
+        @NotBlank(message = "공지 내용은 필수입니다.")
+        String content,
+
+        boolean published
+) {
+}

--- a/src/main/java/or/ecogad/ecogad/api/notice/dto/AdminNoticeCreateResponse.java
+++ b/src/main/java/or/ecogad/ecogad/api/notice/dto/AdminNoticeCreateResponse.java
@@ -1,0 +1,25 @@
+package or.ecogad.ecogad.api.notice.dto;
+
+import or.ecogad.ecogad.domain.notice.entity.Notice;
+
+import java.time.LocalDateTime;
+
+public record AdminNoticeCreateResponse(
+        Long id,
+        String title,
+        String content,
+        boolean published,
+        LocalDateTime publishedAt,
+        LocalDateTime createdAt
+) {
+    public static AdminNoticeCreateResponse from(Notice notice) {
+        return new AdminNoticeCreateResponse(
+                notice.getId(),
+                notice.getTitle(),
+                notice.getContent(),
+                notice.isPublished(),
+                notice.getPublishedAt(),
+                notice.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/or/ecogad/ecogad/core/exception/ErrorCode.java
+++ b/src/main/java/or/ecogad/ecogad/core/exception/ErrorCode.java
@@ -6,6 +6,7 @@ public enum ErrorCode {
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C400", "요청 값이 올바르지 않습니다."),
     INVALID_PRODUCT_CATEGORY(HttpStatus.BAD_REQUEST, "P400", "유효하지 않은 제품 카테고리입니다."),
     DUPLICATE_PRODUCT(HttpStatus.CONFLICT, "P409", "동일 카테고리에 같은 이름의 제품이 이미 존재합니다."),
+    DUPLICATE_NOTICE(HttpStatus.CONFLICT, "N409", "같은 제목의 공지사항이 이미 존재합니다."),
     INQUIRY_NOTIFICATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "I500", "견적 문의 알림 메일 전송에 실패했습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C500", "서버 내부 오류가 발생했습니다.");
 

--- a/src/main/java/or/ecogad/ecogad/domain/notice/entity/Notice.java
+++ b/src/main/java/or/ecogad/ecogad/domain/notice/entity/Notice.java
@@ -1,0 +1,49 @@
+package or.ecogad.ecogad.domain.notice.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import or.ecogad.ecogad.domain.common.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "notices")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private boolean published;
+
+    private LocalDateTime publishedAt;
+
+    private Notice(String title, String content, boolean published) {
+        this.title = title;
+        this.content = content;
+        this.published = published;
+        this.publishedAt = published ? LocalDateTime.now() : null;
+    }
+
+    public static Notice create(String title, String content, boolean published) {
+        return new Notice(title, content, published);
+    }
+}

--- a/src/main/java/or/ecogad/ecogad/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/or/ecogad/ecogad/domain/notice/repository/NoticeRepository.java
@@ -1,0 +1,9 @@
+package or.ecogad.ecogad.domain.notice.repository;
+
+import or.ecogad.ecogad.domain.notice.entity.Notice;
+
+public interface NoticeRepository {
+    Notice save(Notice notice);
+
+    boolean existsByTitle(String title);
+}

--- a/src/main/java/or/ecogad/ecogad/domain/notice/service/AdminNoticeService.java
+++ b/src/main/java/or/ecogad/ecogad/domain/notice/service/AdminNoticeService.java
@@ -1,0 +1,27 @@
+package or.ecogad.ecogad.domain.notice.service;
+
+import lombok.RequiredArgsConstructor;
+import or.ecogad.ecogad.core.exception.CustomException;
+import or.ecogad.ecogad.core.exception.ErrorCode;
+import or.ecogad.ecogad.domain.notice.entity.Notice;
+import or.ecogad.ecogad.domain.notice.repository.NoticeRepository;
+import or.ecogad.ecogad.domain.notice.service.command.NoticeCreateCommand;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminNoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    @Transactional
+    public Notice createNotice(NoticeCreateCommand command) {
+        if (noticeRepository.existsByTitle(command.title())) {
+            throw new CustomException(ErrorCode.DUPLICATE_NOTICE);
+        }
+
+        Notice notice = Notice.create(command.title(), command.content(), command.published());
+        return noticeRepository.save(notice);
+    }
+}

--- a/src/main/java/or/ecogad/ecogad/domain/notice/service/command/NoticeCreateCommand.java
+++ b/src/main/java/or/ecogad/ecogad/domain/notice/service/command/NoticeCreateCommand.java
@@ -1,0 +1,8 @@
+package or.ecogad.ecogad.domain.notice.service.command;
+
+public record NoticeCreateCommand(
+        String title,
+        String content,
+        boolean published
+) {
+}

--- a/src/main/java/or/ecogad/ecogad/infra/notice/jpa/NoticeJpaRepository.java
+++ b/src/main/java/or/ecogad/ecogad/infra/notice/jpa/NoticeJpaRepository.java
@@ -1,0 +1,8 @@
+package or.ecogad.ecogad.infra.notice.jpa;
+
+import or.ecogad.ecogad.domain.notice.entity.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeJpaRepository extends JpaRepository<Notice, Long> {
+    boolean existsByTitle(String title);
+}

--- a/src/main/java/or/ecogad/ecogad/infra/notice/repository/NoticeRepositoryImpl.java
+++ b/src/main/java/or/ecogad/ecogad/infra/notice/repository/NoticeRepositoryImpl.java
@@ -1,0 +1,24 @@
+package or.ecogad.ecogad.infra.notice.repository;
+
+import lombok.RequiredArgsConstructor;
+import or.ecogad.ecogad.domain.notice.entity.Notice;
+import or.ecogad.ecogad.domain.notice.repository.NoticeRepository;
+import or.ecogad.ecogad.infra.notice.jpa.NoticeJpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class NoticeRepositoryImpl implements NoticeRepository {
+
+    private final NoticeJpaRepository noticeJpaRepository;
+
+    @Override
+    public Notice save(Notice notice) {
+        return noticeJpaRepository.save(notice);
+    }
+
+    @Override
+    public boolean existsByTitle(String title) {
+        return noticeJpaRepository.existsByTitle(title);
+    }
+}

--- a/src/test/java/or/ecogad/ecogad/domain/notice/service/AdminNoticeServiceTest.java
+++ b/src/test/java/or/ecogad/ecogad/domain/notice/service/AdminNoticeServiceTest.java
@@ -1,0 +1,61 @@
+package or.ecogad.ecogad.domain.notice.service;
+
+import or.ecogad.ecogad.core.exception.CustomException;
+import or.ecogad.ecogad.domain.notice.entity.Notice;
+import or.ecogad.ecogad.domain.notice.repository.NoticeRepository;
+import or.ecogad.ecogad.domain.notice.service.command.NoticeCreateCommand;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminNoticeServiceTest {
+
+    @Mock
+    private NoticeRepository noticeRepository;
+
+    @InjectMocks
+    private AdminNoticeService adminNoticeService;
+
+    @Test
+    @DisplayName("createNotice()는 공지사항을 성공적으로 등록한다")
+    void createNotice_success() {
+        NoticeCreateCommand command = new NoticeCreateCommand(
+                "시스템 점검 공지",
+                "점검이 예정되어 있습니다.",
+                true
+        );
+
+        when(noticeRepository.existsByTitle("시스템 점검 공지")).thenReturn(false);
+        when(noticeRepository.save(any(Notice.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        adminNoticeService.createNotice(command);
+
+        verify(noticeRepository, times(1)).save(any(Notice.class));
+    }
+
+    @Test
+    @DisplayName("createNotice()는 제목이 중복되면 예외를 발생시킨다")
+    void createNotice_duplicate_throwsException() {
+        NoticeCreateCommand command = new NoticeCreateCommand(
+                "시스템 점검 공지",
+                "점검이 예정되어 있습니다.",
+                false
+        );
+
+        when(noticeRepository.existsByTitle("시스템 점검 공지")).thenReturn(true);
+
+        assertThrows(CustomException.class, () -> adminNoticeService.createNotice(command));
+        verify(noticeRepository, never()).save(any(Notice.class));
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- close #3


<br><br>

## 📝 Summary

- 공지사항 작성 어드민 API 추가 (`POST /api/v1/admin/notices`)
- 공지 도메인/인프라 계층 구현
- 공지 작성 서비스 단위 테스트 추가


<br><br>

## 🙏 Details

- `Notice` 엔티티 추가 (`title`, `content`, `published`, `publishedAt`)
- 제목 중복 방지 로직 추가 (`existsByTitle`)
- 중복 시 `DUPLICATE_NOTICE` 예외 반환
- 요청값 검증(`@Valid`) 적용
- 검증/실행 확인: `./gradlew test` 성공
