### PR TITLE
fix: CD SSH 포트 2222 반영

### DIFF
--- a/.github/workflows/develop-cd.yml
+++ b/.github/workflows/develop-cd.yml
@@ -83,6 +83,7 @@ jobs:
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.EC2_HOST }}
+          port: 2222
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           source: deploy/ec2/blue_green_deploy.sh
@@ -92,6 +93,7 @@ jobs:
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.EC2_HOST }}
+          port: 2222
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script_stop: true


### PR DESCRIPTION
## 변경사항\n- scp-action 포트를 2222로 고정\n- ssh-action 포트를 2222로 고정\n\n## 목적\n- EC2가 2222 포트만 열려 있어 배포 스크립트 전송 실패하던 문제 해결