### PR TITLE
fix: Swagger UI 접속 및 404 응답 코드 보정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/or/ecogad/ecogad/core/exception/ErrorCode.java
+++ b/src/main/java/or/ecogad/ecogad/core/exception/ErrorCode.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C400", "요청 값이 올바르지 않습니다."),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "C404", "요청한 리소스를 찾을 수 없습니다."),
     INVALID_PRODUCT_CATEGORY(HttpStatus.BAD_REQUEST, "P400", "유효하지 않은 제품 카테고리입니다."),
     DUPLICATE_PRODUCT(HttpStatus.CONFLICT, "P409", "동일 카테고리에 같은 이름의 제품이 이미 존재합니다."),
     DUPLICATE_NOTICE(HttpStatus.CONFLICT, "N409", "같은 제목의 공지사항이 이미 존재합니다."),

--- a/src/main/java/or/ecogad/ecogad/core/exception/GlobalExceptionHandler.java
+++ b/src/main/java/or/ecogad/ecogad/core/exception/GlobalExceptionHandler.java
@@ -6,6 +6,8 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -26,6 +28,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.INVALID_INPUT_VALUE.status())
                 .body(ApiResponse.failure(ErrorCode.INVALID_INPUT_VALUE.code(), message));
+    }
+
+    @ExceptionHandler({NoResourceFoundException.class, NoHandlerFoundException.class})
+    public ResponseEntity<ApiResponse<Void>> handleNotFound(Exception exception) {
+        return ResponseEntity
+                .status(ErrorCode.RESOURCE_NOT_FOUND.status())
+                .body(ApiResponse.failure(ErrorCode.RESOURCE_NOT_FOUND.code(), ErrorCode.RESOURCE_NOT_FOUND.message()));
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## 관련 이슈\n- closes #11\n\n## 변경 사항\n- springdoc-openapi UI 의존성 추가\n- 리소스 미존재 예외를 404(C404)로 반환하도록 GlobalExceptionHandler 보완\n\n## 검증\n- ./gradlew clean build --no-daemon